### PR TITLE
fix: recover Hessian/trust-radius updates after internal-coord rebuild

### DIFF
--- a/pysisyphus/Geometry.py
+++ b/pysisyphus/Geometry.py
@@ -620,6 +620,12 @@ class Geometry:
 
                 self.internal = coord_class(self.atoms, coords3d, **coord_kwargs)
                 self._coords = coords3d.flatten()
+                # The coordinates changed (step applied) and the internals were
+                # rebuilt, so any cached energy/forces/Hessian belong to the old
+                # geometry. Clear them, otherwise the optimizer's reset() silently
+                # reuses a stale cached Hessian instead of recomputing at the new
+                # geometry (matches the normal set_coords path, which also clears).
+                self.clear()
                 raise RebuiltInternalsException(
                     typed_prims=self.internal.typed_prims.copy()
                 )

--- a/pysisyphus/optimizers/HessianOptimizer.py
+++ b/pysisyphus/optimizers/HessianOptimizer.py
@@ -466,8 +466,12 @@ class HessianOptimizer(Optimizer):
             len(self.forces) > 1
             and (self.forces[-2].shape == gradient.shape)
             and len(self.coords) > 1
-            # Coordinates may have been rebuilt. Take care of that.
-            and (self.coords[-2].shape == self.coords[1].shape)
+            # Coordinates may have been rebuilt, changing the coordinate count.
+            # Only the single cycle spanning the rebuild has mismatched shapes, so
+            # compare the two most recent coordinate sets (not a fixed early one):
+            # otherwise every post-rebuild cycle stays False and the Hessian/trust
+            # radius updates are frozen for the rest of the optimization.
+            and (self.coords[-1].shape == self.coords[-2].shape)
             and len(self.energies) > 1
         )
         if can_update:


### PR DESCRIPTION
## Problem

When redundant internal coordinates are **rebuilt** mid-optimization (the primitive count changes, e.g. 180 → 172), the optimizer froze and oscillated to `max_cycles` instead of converging. This shows up on floppy Li-electrolyte complexes (SEI campaigns) where Li coordination migration routinely invalidates bends/dihedrals and triggers a rebuild. Two bugs combine:

1. **`optimizers/HessianOptimizer.py` — `housekeeping()`**: the `can_update` guard compared `self.coords[-2].shape == self.coords[1].shape` — a *fixed early snapshot*. Once a rebuild changes the coordinate count, this stays `False` for **every** remaining cycle, so `update_hessian()` and `update_trust_radius()` are never called again: `hessian_recalc` is silently ignored, the Hessian is frozen at the pre-rebuild guess, and the trust radius never adapts. Fixed by comparing the two most recent coordinate sets, so only the single cycle spanning the rebuild is skipped and updates resume afterwards.

2. **`Geometry.py` — `set_coords()`**: the rebuild branch set new coordinates but did **not** clear cached results, so the stale `_hessian` survived. The optimizer's `reset()` with `hessian_init='calc'` then silently reused that stale Hessian instead of recomputing at the new geometry. Fixed by calling `self.clear()` in the rebuild branch, exactly as the normal `set_coords` path already does.

## Validation

Same input (a Li/PF6/EC complex that triggers rebuilds), same version, same xTB calculator, RS-PRFO / redund / `trust_radius=0.5`:

| | rebuilds | outcome |
|---|---|---|
| before | 2 | **50 cycles exceeded**; energy oscillates ±1e-3 Eh, forces & step frozen |
| after  | 4 | **converges in ~36 cycles** (force convergence overachieved) |

The "before" tail is the classic frozen-Hessian oscillation (alternating ΔE sign, `rms(step)` pinned).

2 files changed, +12/−2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)