### PR TITLE
fix: guard RS-PRFO against singular restricted-step scaling (rebuild follow-up)

### DIFF
--- a/pysisyphus/__version__.py
+++ b/pysisyphus/__version__.py
@@ -1,3 +1,3 @@
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 __all__ = ["__version__"]

--- a/pysisyphus/tsoptimizers/RSPRFOptimizer.py
+++ b/pysisyphus/tsoptimizers/RSPRFOptimizer.py
@@ -136,10 +136,22 @@ class RSPRFOptimizer(TSHessianOptimizer):
                 )
             )
             dstep2_dalpha = dstep2_dalpha_max + dstep2_dalpha_min
+            # Guard the restricted-step derivative against a singularity: when an RFO
+            # eigenvalue approaches a Hessian eigenvalue the denominator (…)**3 -> 0,
+            # and near convergence the numerator -> 0 too, giving 0/0 = nan. Left
+            # unchecked this makes alpha (and the resulting step) non-finite, which
+            # blows the geometry up. Stop refining alpha and use the current step,
+            # which is scaled to the trust radius below.
+            if (not np.isfinite(dstep2_dalpha)) or (dstep2_dalpha == 0.0):
+                self.log("Singular restricted-step derivative; stopping micro-cycles.")
+                break
             # Update alpha
             alpha_step = (
                 2 * (self.trust_radius * step_norm - step_norm**2) / dstep2_dalpha
             )
+            if not np.isfinite(alpha_step):
+                self.log("Non-finite alpha step; stopping micro-cycles.")
+                break
             alpha += alpha_step
 
         # Right now the step is still given in the Hessians eigensystem. We
@@ -148,11 +160,24 @@ class RSPRFOptimizer(TSHessianOptimizer):
         step = eigvecs.dot(step)
         step_norm = np.linalg.norm(step)
 
-        # With max_micro_cycles = 1 the RS part is disabled and the step
-        # probably isn't scaled correctly in the one micro cycle.
-        # In this case we use a naive scaling if the step is too big.
-        if (self.max_micro_cycles == 1) and (step_norm > self.trust_radius):
+        # Fall back to naive scaling when the restricted-step procedure did not
+        # yield a sane step. This covers max_micro_cycles == 1 (RS disabled), an
+        # early break from the singularity guard above, and RFO/alpha singularities
+        # that leave the step non-finite.
+        if not np.all(np.isfinite(step)):
+            self.log(
+                "Non-finite RS-PRFO step; falling back to a trust-radius step "
+                "along the gradient direction."
+            )
+            grad_norm = np.linalg.norm(gradient)
+            if grad_norm == 0.0:
+                step = np.zeros_like(step)
+            else:
+                step = -gradient / grad_norm * self.trust_radius
+            step_norm = np.linalg.norm(step)
+        elif step_norm > self.trust_radius:
             step = step / step_norm * self.trust_radius
+            step_norm = np.linalg.norm(step)
         self.log(f"norm(step)={np.linalg.norm(step):.6f}")
 
         # Eq. (6) from [4] seems erronous ... the prediction is usually only ~50%


### PR DESCRIPTION
Follow-up to #10 (merged). Recomputing the Hessian after an internal-coordinate rebuild — the behaviour #10 restored — can land the RS-PRFO restricted-step solver in a degenerate state: near convergence (gradient ≈ 0) with an RFO eigenvalue close to a Hessian eigenvalue, the alpha derivative

```
sum( g[max]**2 / (eigvals[max] - eigval_max * alpha)**3 )
```

evaluates `0/0 = nan` (`RuntimeWarning: divide by zero`). `alpha` then goes non-finite, the step explodes (observed ~7e20), the geometry is destroyed, and the next cycle raises `ZeroStepLength`, crashing the run. Reported on a real gxTB redund TS-opt right after #10 was deployed:

```
27  ...  0.204137     0.036179     8.27
Rebuilt internal coordinates!
RSPRFOptimizer.py:124: RuntimeWarning: divide by zero encountered in divide
28   0.000000*  0.000511  0.000089*  741060493397010022400.0  142409640637410000896.0
Rebuilt internal coordinates!
29   0.000000*  0.002028  0.000219*  0.000000*  0.000000*
... raise ZeroStepLength
```

### Fix (`RSPRFOptimizer.optimize()`)
- Stop refining `alpha` when the restricted-step derivative is zero/non-finite, or the resulting alpha step is non-finite (use the current step, scaled below).
- Generalise the trust-radius fallback: scale **any** step exceeding the trust radius (previously only `max_micro_cycles == 1`); if the step is still non-finite, fall back to a trust-radius step along the gradient (zero step when the gradient vanishes).

### Validation
xTB redund RS-PRFO TS-opt on the Li/PF6/EC complex still converges in ~36 cycles with 4 rebuilds, recomputes the Hessian every post-recovery cycle, and shows no `divide by zero` / `ZeroStepLength`. This removes the numerical blow-up that #10 exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)