### PR TITLE
fix: eliminate RS-PRFO 0/0 at source (1.0.7) — follow-up to #11

### DIFF
--- a/pysisyphus/__version__.py
+++ b/pysisyphus/__version__.py
@@ -1,3 +1,3 @@
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 __all__ = ["__version__"]

--- a/pysisyphus/tsoptimizers/RSPRFOptimizer.py
+++ b/pysisyphus/tsoptimizers/RSPRFOptimizer.py
@@ -114,36 +114,36 @@ class RSPRFOptimizer(TSHessianOptimizer):
                 )
                 break
 
-            # Derivative of the squared step w.r.t. alpha
+            # Derivative of the squared step w.r.t. alpha. Each summand
+            #   g_i**2 / (eigval_i - rfo_eigval * alpha)**3
+            # is singular when an RFO eigenvalue meets a Hessian eigenvalue. Near
+            # convergence the numerator g_i -> 0 as well, so the physical limit of
+            # the 0/0 term is 0. Evaluate it that way (safe divide) instead of
+            # letting it produce nan, which otherwise propagates into alpha and
+            # either blows the step up or leaves it degenerate (a null-space step
+            # that does not move the geometry, ending in ZeroStepLength).
+            def _dstep2(grad_sub, eigvals_sub, rfo_eigval, quad):
+                num = grad_sub ** 2
+                den = (eigvals_sub - rfo_eigval * alpha) ** 3
+                quot = np.divide(num, den, out=np.zeros_like(num), where=(den != 0.0))
+                return 2 * rfo_eigval / (1 + quad) * np.sum(quot)
+
             # max subspace
-            dstep2_dalpha_max = (
-                2
-                * eigval_max
-                / (1 + step_max.dot(step_max) ** 2 * alpha)
-                * np.sum(
-                    gradient_trans[max_indices] ** 2
-                    / (eigvals[max_indices] - eigval_max * alpha) ** 3
-                )
+            dstep2_dalpha_max = _dstep2(
+                gradient_trans[max_indices], eigvals[max_indices], eigval_max,
+                step_max.dot(step_max) ** 2 * alpha,
             )
             # min subspace
-            dstep2_dalpha_min = (
-                2
-                * eigval_min
-                / (1 + step_min.dot(step_min) * alpha)
-                * np.sum(
-                    gradient_trans[min_indices] ** 2
-                    / (eigvals[min_indices] - eigval_min * alpha) ** 3
-                )
+            dstep2_dalpha_min = _dstep2(
+                gradient_trans[min_indices], eigvals[min_indices], eigval_min,
+                step_min.dot(step_min) * alpha,
             )
             dstep2_dalpha = dstep2_dalpha_max + dstep2_dalpha_min
-            # Guard the restricted-step derivative against a singularity: when an RFO
-            # eigenvalue approaches a Hessian eigenvalue the denominator (…)**3 -> 0,
-            # and near convergence the numerator -> 0 too, giving 0/0 = nan. Left
-            # unchecked this makes alpha (and the resulting step) non-finite, which
-            # blows the geometry up. Stop refining alpha and use the current step,
-            # which is scaled to the trust radius below.
+            # If the derivative still vanishes or is non-finite, alpha cannot be
+            # refined further; stop and let the trust-radius scaling below bound
+            # the step.
             if (not np.isfinite(dstep2_dalpha)) or (dstep2_dalpha == 0.0):
-                self.log("Singular restricted-step derivative; stopping micro-cycles.")
+                self.log("Restricted-step derivative not usable; stopping micro-cycles.")
                 break
             # Update alpha
             alpha_step = (


### PR DESCRIPTION
Follow-up to #11 (merged). #11 landed the first RS-PRFO guard, but it only detected the non-finite restricted-step derivative *after the fact* and broke the micro-cycle, leaving `alpha` unrefined and the step degenerate. On a real gxTB redund run this turned the earlier ~7e20 blow-up into a step that shrank to zero over a few cycles (geometry frozen, forces pinned at 0.003058) and still crashed with `ZeroStepLength`, while `divide by zero encountered in divide` kept firing at `RSPRFOptimizer.py:124`.

### Fix
Eliminate the singular summand at its source:

```
g_i**2 / (eigval_i - rfo_eigval * alpha)**3
```

Near convergence the numerator `g_i -> 0`, so the physical limit of the 0/0 term is 0. Evaluate it with a safe divide (`np.divide(num, den, out=zeros, where=den!=0)`) so the derivative stays finite, `alpha` is refined normally, and the step is properly restricted to the trust radius instead of degenerating. The finite/zero-derivative break and the trust-radius / non-finite-step fallbacks from #11 are kept as backstops.

Bumps version to **1.0.7** (tag `v1.0.7`) so `pip install` from git actually reinstalls.

### Validation
xTB redund RS-PRFO on the Li/PF6/EC complex still converges (4 rebuilds, no `ZeroStepLength`) and the divide-by-zero warning is gone. The exact gxTB crash could not be reproduced locally (xTB doesn't trigger the rebuild on that geometry); definitive check is redeploying `@v1.0.7` on the gxTB host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)